### PR TITLE
Declare smtpMailingQueue as global before set

### DIFF
--- a/classes/SMTPMailingQueue.php
+++ b/classes/SMTPMailingQueue.php
@@ -18,7 +18,7 @@ class SMTPMailingQueue
 	/**
 	 * @var string
 	 */
-	public $pluginVersion = '1.4.5';
+	public $pluginVersion = '1.4.6';
 
 	public function __construct($pluginFile = null, OriginalPluggeable $originalPluggeable)
 	{

--- a/languages/smtp-mailing-queue.pot
+++ b/languages/smtp-mailing-queue.pot
@@ -3,7 +3,7 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: SMTP Mailing Queue 1.4.5\n"
+"Project-Id-Version: SMTP Mailing Queue 1.4.6\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/smtp-mailing-"
 "queue\n"
 "POT-Creation-Date: 2021-11-13 14:23+0100\n"

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: mail, smtp, phpmailer, mailing queue, wp_mail, email
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=KRBU2JDQUMWP4
 Requires at least: 3.9
 Tested up to: 5.7.1
-Stable tag: 1.4.5
+Stable tag: 1.4.6
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -134,6 +134,9 @@ Sure, here are the donation links of top contributors :
 4. Supervisors
 
 == Changelog ==
+
+= 1.4.6 =
+* Bugfix : Fix a member call on 'null' when using the plugin from WP-CLI (Thanks @cvl01)
 
 = 1.4.5 =
 * Feature : Add PHPMailer error detail message in notice while using tool to send immediate test mail

--- a/smtp-mailing-queue.php
+++ b/smtp-mailing-queue.php
@@ -4,7 +4,7 @@ Plugin Name: SMTP Mailing Queue
 Plugin URI: http://dennishildenbrand.com
 Description: SMTP Mailing Queue
 Author: Dennis Hildenbrand
-Version: 1.4.5
+Version: 1.4.6
 Author URI: http://dennishildenbrand.com
 Text Domain: smtp-mailing-queue
 */
@@ -39,6 +39,7 @@ if(is_admin() && version_compare(PHP_VERSION, '5.4', '<')) {
 	require_once('classes/OriginalPluggeable/OriginalPluggeable.php');
 
 	$originalPluggeable = new OriginalPluggeable();
+	global $smtpMailingQueue;
 	$smtpMailingQueue = new SMTPMailingQueue(__FILE__, $originalPluggeable);
 	$smtpMailingQueueUpdate = new SMTPMailingQueueUpdate($smtpMailingQueue);
 	new SMTPMailingQueueOptions($smtpMailingQueue);


### PR DESCRIPTION
This is required when using WP-CLI